### PR TITLE
Visual mode bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,10 @@ Default: `{ "Man", "!" }`
 
 You can specify ignore command name.
 
+### treat_trailing_slash: boolean
+Default: `true`
+
+`vim.fn.getcompletion` can return path items.
+unfortunately, that items has trailing slash so we don't narrowing with next directory with pressing `/`.
+
+if you turnd on this option, `cmp-cmdline` removes trailing slash automatically.

--- a/lua/cmp_cmdline/init.lua
+++ b/lua/cmp_cmdline/init.lua
@@ -83,6 +83,8 @@ local definitions = {
     isIncomplete = true,
     ---@param option cmp-cmdline.Option
     exec = function(option, arglead, cmdline, force)
+      -- Any edits we produce are relative to the whole command line.
+      local cmdline_length = #cmdline
       -- Ignore range only cmdline. (e.g.: 4, '<,'>)
       if not force and ONLY_RANGE_REGEX:match_str(cmdline) then
         return {}
@@ -120,11 +122,7 @@ local definitions = {
       -- In this case, the `vim.fn.getcompletion` will return only `get_query` for `vim.treesitter.get_|`.
       -- We should detect `vim.treesitter.` and `get_query` separately.
       -- TODO: The `\h\w*` was choosed by huristic. We should consider more suitable detection.
-      local fixed_input
-      do
-        local suffix_pos = vim.regex([[\h\w*$]]):match_str(arglead)
-        fixed_input = string.sub(arglead, 1, suffix_pos or #arglead)
-      end
+      local fixed_input = arglead
 
       -- The `vim.fn.getcompletion` does not return `*no*cursorline` option.
       -- cmp-cmdline corrects `no` prefix for option name.
@@ -133,6 +131,13 @@ local definitions = {
       --- create items.
       local items = {}
       local escaped = cmdline:gsub([[\\]], [[\\\\]]);
+      local is_magic_file = false
+      local input_start = string.sub(fixed_input, 1, 1)
+      if input_start == '%' then
+        is_magic_file = true
+      elseif input_start == '#' then
+        is_magic_file = true
+      end
       for _, word_or_item in ipairs(vim.fn.getcompletion(escaped, 'cmdline')) do
         local word = type(word_or_item) == 'string' and word_or_item or word_or_item.word
         local item = { label = word }
@@ -147,8 +152,24 @@ local definitions = {
 
       -- fix label with `fixed_input`
       for _, item in ipairs(items) do
-        if not string.find(item.label, fixed_input, 1, true) then
+        if not is_magic_file and not string.find(item.label, fixed_input, 1, true) then
           item.label = fixed_input .. item.label
+        end
+        if is_magic_file then
+          local replace_range = {
+            start = {
+              character = cmdline_length - #fixed_input - 1
+            },
+            ['end'] = {
+              character = cmdline_length - 1
+            }
+          }
+          item.textEdit = {
+            replace = replace_range,
+            range = replace_range,
+            newText = item.label
+          }
+          item.label = fixed_input .. ' → ' .. item.label
         end
       end
 
@@ -217,6 +238,20 @@ source.complete = function(self, params, callback)
   for _, item in ipairs(items) do
     item.kind = kind
     labels[item.label] = true
+    if item['textEdit'] ~= nil then
+      local new_range = {
+        start = {
+          character = item.textEdit.range.start.character,
+          line = params.context.cursor.line
+        },
+        ['end'] = {
+          character = item.textEdit.range['end'].character,
+          line = params.context.cursor.line
+        }
+      }
+      item.textEdit.replace = new_range
+      item.textEdit.range = new_range
+    end
   end
 
   -- `vim.fn.getcompletion` does not handle fuzzy matches. So, we must return all items, including items that were matched in the previous input.

--- a/lua/cmp_cmdline/init.lua
+++ b/lua/cmp_cmdline/init.lua
@@ -122,7 +122,11 @@ local definitions = {
       -- In this case, the `vim.fn.getcompletion` will return only `get_query` for `vim.treesitter.get_|`.
       -- We should detect `vim.treesitter.` and `get_query` separately.
       -- TODO: The `\h\w*` was choosed by huristic. We should consider more suitable detection.
-      local fixed_input = arglead
+      local fixed_input
+      do
+        local suffix_pos = vim.regex([[\h\w*$]]):match_str(arglead)
+        fixed_input = string.sub(arglead, 1, suffix_pos or #arglead)
+      end
 
       -- The `vim.fn.getcompletion` does not return `*no*cursorline` option.
       -- cmp-cmdline corrects `no` prefix for option name.


### PR DESCRIPTION
This PR tries to do two things:

1. Keep the `%` autocomplete; we cannot live without it XD while a small bug with visual mode where the current behavior
    doesn't take into consideration what already has been typed into the cmdline
![2024-04-23_17-20](https://github.com/iteratee/cmp-cmdline/assets/34474472/b2f9299d-1db2-444f-ad80-fc804bc53bd3)
2. Rebase the branch on top of [hrsh7th/cmp-cmdline:main](https://github.com/hrsh7th/cmp-cmdline)

No it's better
![2024-04-23_17-54](https://github.com/iteratee/cmp-cmdline/assets/34474472/35b7bfc2-fdf6-448e-a508-830185f3ad45)

My initial testing went OK, no problems so far. 